### PR TITLE
Add c2d-contributors for rotation upgrades

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
 *                   @GoogleCloudPlatform/launcher-operations
+*		    @GoogleCloudPlatform/c2d-contributors


### PR DESCRIPTION
As previously accorded, c2d-contributors are able to merge rotation PRs with an internal approval. 

For major changes, launcher-operations will be requested to review.